### PR TITLE
v1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 
 配置文件在`v1.1.0`支持了热重载, 同时添加了更完善的属性补全功能。当新版本的配置文件中新增了某一选项, 插件将会自动将默认值填写到你的旧配置文件中, 而不需要手动添加。
 
-```json
+```jsonc
 {
     "!!mirror": {
         "mcsm": {/* MCSManager配置 */},
@@ -81,7 +81,7 @@
 镜像服1为`!!mirror`，同时也是其他镜像服的默认配置文件，那么将`!!mirror`放在配置文件中的第一个
 
 通过`!!mirror2`控制镜像服2，并设置`!!mirror2`的实例id为`abc123`，将`!!mirror2`的服务端名称改为`Mirror2`
-```json
+```jsonc
 {
     "!!mirror": {
         // ...
@@ -104,7 +104,7 @@
 
 ### mcsm: MCSManager配置
 此配置部分若有疑问，请参见[MCSManager官方文档](https://docs.mcsmanager.com/#/zh-cn/apis/readme)
-```json
+```jsonc
 "mcsm": {
     "enable": false,
     "url": "http://127.0.0.1:23333/",
@@ -133,7 +133,7 @@
 <br>
 
 ### terminal: 通过命令行启动镜像服终端的配置
-```json
+```jsonc
 "terminal": {
     "enable": false,
     "launch_path": "./Mirror",
@@ -179,7 +179,7 @@
 <br>
 
 ### rcon: RCON配置
-```json
+```jsonc
 "rcon": {
     "enable": false,
     "address": null,
@@ -202,7 +202,7 @@
 <br>
 
 ### sync: 文件同步相关的配置文件
-```json
+```jsonc
 "sync": {
     "world": [
 	"world"
@@ -255,7 +255,7 @@ mcdr_root (./)
 
 ### command: 指令配置
 
-```json
+```jsonc
 "command": {
     "permission": {/* 指令权限配置 */},
     "action": {/* 指令行为配置 */}
@@ -265,7 +265,7 @@ mcdr_root (./)
 <br>
 
 ### permission: 指令权限配置
-```json
+```jsonc
 "permission": {
     "status": 0,
     "start": 0,
@@ -282,7 +282,7 @@ mcdr_root (./)
 <br>
 
 ### action: 指令行为配置
-```json
+```jsonc
 "action": {
     "status": {
         "require_confirm": false
@@ -334,7 +334,7 @@ mcdr_root (./)
 - 此选项仅在`auto_server_restart`生效时生效。检查镜像服状态的尝试次数, 超过此尝试次数后将不再尝试检查镜像服状态, 并输出`自动关闭失败`及镜像服当前状态信息。等效于超时时间 `timeout = check_status_interval * max_attempt_times`
 
 **save_world** 保存世界配置 *一般无需更改*
-```json
+```jsonc
 "save_world": {
     "turn_off_auto_save": true,
     "commands": {
@@ -378,7 +378,7 @@ mcdr_root (./)
 <br>
 
 ### display: 显示配置
-```json
+```jsonc
 "display": {
     "server_name": "Mirror"
 }
@@ -390,7 +390,7 @@ mcdr_root (./)
 
 ### 多镜像服配置文件示例
 
-```json
+```jsonc
 {
     "!!mirror": {
         "mcsm": {

--- a/README_en.md
+++ b/README_en.md
@@ -53,7 +53,7 @@ The default command prefix is `!!mirror`. When controlling multiple mirror serve
 
 The configuration file supported hot reloading in `v1.1.0`, and at the same time added a more comprehensive attribute completion function. When a new version of the configuration file adds an option, the plugin will automatically fill in the default value in your old configuration file, without the need for manual addition.
 
-```json
+```jsonc
 {
     "!!mirror": {
         "mcsm": {/* MCSManager configuration */},
@@ -81,7 +81,7 @@ The parameters set for the first mirror server in the configuration file will al
 Mirror server 1 is `!!mirror`, which is also the default configuration file for other mirror servers, then put `!!mirror` in the first place in the configuration file.
 
 Control mirror server 2 through `!!mirror2`, and set the instance id of `!!mirror2` to `abc123`, change the server name of `!!mirror2` to `Mirror2`
-```json
+```jsonc
 {
     "!!mirror": {
         // ...
@@ -104,7 +104,7 @@ For a complete example, see [Multi-mirror Server Configuration File Example](#ex
 
 ### mcsm: MCSManager Configuration
 If you have any questions about this configuration section, please refer to the [MCSManager Documentation](https://docs.mcsmanager.com/#/zh-cn/apis/readme) 
-```json
+```jsonc
 "mcsm": {
     "enable": false,
     "url": "http://127.0.0.1:23333/", 
@@ -133,7 +133,7 @@ After enabling MCSM, the terminal and RCON will be disabled.
 <br>
 
 ### terminal: Configuration for starting the mirror server terminal through the command line
-```json
+```jsonc
 "terminal": {
     "enable": false,
     "launch_path": "./Mirror",
@@ -179,7 +179,7 @@ Note: Under Linux system, the plugin can close the mirror server through the scr
 <br>
 
 ### rcon: RCON Configuration
-```json
+```jsonc
 "rcon": {
     "enable": false,
     "address": null,
@@ -202,7 +202,7 @@ Note: Under Linux system, the plugin can close the mirror server through the scr
 <br>
 
 ### sync: Configuration file related to file synchronization
-```json
+```jsonc
 "sync": {
     "world": [
 	"world"
@@ -255,7 +255,7 @@ mcdr_root (./)
 
 ### command: Command Configuration
 
-```json
+```jsonc
 "command": {
     "permission": {/* Command permission configuration */},
     "action": {/* Command behavior configuration */}
@@ -265,7 +265,7 @@ mcdr_root (./)
 <br>
 
 ### permission: Command Permission Configuration
-```json
+```jsonc
 "permission": {
     "status": 0,
     "start": 0,
@@ -282,7 +282,7 @@ mcdr_root (./)
 <br>
 
 ### action: Command Behavior Configuration
-```json
+```jsonc
 "action": {
     "status": {
         "require_confirm": false
@@ -333,7 +333,7 @@ mcdr_root (./)
 - This option only takes effect when `auto_server_restart` is in effect. The number of attempts to check the status of the mirror server, after exceeding this number of attempts, it will no longer attempt to check the status of the mirror server, and output `automatic shutdown failed` and the current status information of the mirror server. Equivalent to the timeout time `timeout = check_status_interval * max_attempt_times`
 
 **save_world** Save world configuration *Generally no need to change*
-```json
+```jsonc
 "save_world": {
     "turn_off_auto_save": true,
     "commands": {
@@ -377,7 +377,7 @@ Players can only confirm the commands they have executed
 <br>
 
 ### display: Display Configuration
-```json
+```jsonc
 "display": {
     "server_name": "Mirror"
 }
@@ -389,7 +389,7 @@ Players can only confirm the commands they have executed
 
 ### Example of Multi-mirror Server Configuration File
 
-```json
+```jsonc
 {
     "!!mirror": {
         "mcsm": {

--- a/lang/en_us.yml
+++ b/lang/en_us.yml
@@ -76,8 +76,8 @@ mirror_mcsmcdr:
         stopped: stopped
         stopping: stopping, please wait for a moment
         starting: starting, please stop after §b{server_name}§c started
-        unavailable: Current config does not support stop command. You need to configure MCSM or RCON
-        unavailable_windows: Windows system does not support execute stop command from terminal. You need to configure MCSM or RCON
+        unavailable:  Current config does not support stop command. You need to configure MCSM or RCON
+        unavailable_windows:  Windows system does not support execute stop command from terminal. You need to configure MCSM or RCON
       success:
         running: stopping command sent
 

--- a/lang/en_us.yml
+++ b/lang/en_us.yml
@@ -3,17 +3,20 @@ mirror_mcsmcdr:
   multi_manager:
     init:
       error: "An error occured when configuring {prefix}: {e}"
-      success: "{prefix} loaded successfully"
-      fail: "{prefix} loaded unsuccessfully"
+      success: "{prefix} §bloaded successfully"
+      fail: "{prefix} §cloaded unsuccessfully"
+      prefix_notfound: "§cConfig file for {prefix} is missing, instance has been disabled"
 
   manager: 
     load: "{prefix} loaded"
     reload:
       success: §aConfig file reloaded successfully§7 ({prefix})
-      fail: §cInvalid config file§7 ({prefix})
+      fail: §cInvalid config file §7({prefix})§c, please check the console and address the error
+      fail.proxy: §cInterface §7({prefix})§c config §4{proxy} §cmisses valid value(s) §4'{keys}'
       fail.unavailable_system: "§cterminal disabled: system {system} unsupported§7 ({prefix})"
     permission_denied: §b{server_name}§c Permission denied
     mcsm_disabled: §cMCSM-API is disbaled
+    unavailable: §cConfig error, §4{prefix}§c instance disabled
   
   command:
 
@@ -30,6 +33,12 @@ mirror_mcsmcdr:
       kill: §7{prefix} kill §fKill {server_name}
       sync: §7{prefix} sync §fSynchronize {server_name}
       reload: §7{prefix} reload §fReload config of {server_name}
+
+    proxy:
+      title: "§eInterface Status"
+      enabled: "§aEnabled"
+      disabled: "§7Disabled"
+      error: "§cConfig error"
 
     confirm:
       prompt: §7{prefix} confirm §fto confirm operation

--- a/lang/zh_cn.yml
+++ b/lang/zh_cn.yml
@@ -76,8 +76,8 @@ mirror_mcsmcdr:
         stopped: 已停止
         stopping: 正在停止, 请稍等
         starting: 正在启动, 请等待§b{server_name}§c启动后重新停止
-        unavailable: 当前配置文件不支持stop命令, 需要配置MCSM或RCON
-        unavailable_windows: Windows系统不支持通过终端执行stop命令, 需要配置MCSM或RCON
+        unavailable: " 当前配置文件不支持stop命令, 需要配置MCSM或RCON"
+        unavailable_windows: " Windows系统不支持通过终端执行stop命令, 需要配置MCSM或RCON"
       success:
         running: 关闭指令已发送
 

--- a/lang/zh_cn.yml
+++ b/lang/zh_cn.yml
@@ -3,17 +3,20 @@ mirror_mcsmcdr:
   multi_manager:
     init:
       error: "设置{prefix}时出错: {e}"
-      success: "{prefix} 构建成功"
-      fail: "{prefix} 构建失败"
+      success: "{prefix} §b构建成功"
+      fail: "{prefix} §c构建失败"
+      prefix_notfound: "§c{prefix} 配置文件缺失, 实例已禁用"
 
   manager: 
     load: "{prefix}已加载"
     reload:
       success: §a配置文件重载成功§7({prefix})
-      fail: §c无效的配置文件§7({prefix})
+      fail: §c无效的配置文件§7({prefix})§c, 请查看控制台并处理报错
+      fail.proxy: §c配置文件§7({prefix})§c的接口 §4{proxy} §c缺少有效值 §4'{keys}'
       fail.unavailable_system: "§cterminal未启用: 不支持{system}系统§7({prefix})"
     permission_denied: §b{server_name}§c操作权限不足
     mcsm_disabled: §cMCSM-API未启用
+    unavailable: §c配置文件错误, §4{prefix}§c实例已禁用
   
   command:
 
@@ -30,6 +33,12 @@ mirror_mcsmcdr:
       kill: §7{prefix} kill §f强制终止{server_name}
       sync: §7{prefix} sync §f同步{server_name}
       reload: §7{prefix} reload §f重载{server_name}配置文件
+
+    proxy:
+      title: "§e接口状态"
+      enabled: "§a已启用"
+      disabled: "§7未启用"
+      error: "§c配置文件错误"
 
     confirm:
       prompt: §7{prefix} confirm §f以确认操作

--- a/mcdreforged.plugin.json
+++ b/mcdreforged.plugin.json
@@ -1,6 +1,6 @@
 {
 	"id": "mirror_mcsmcdr",
-	"version": "1.3.6",
+	"version": "1.4.0",
 	"name": "MirrorMcsmcdR",
 	"description": {
 		"en_us": "A mirror server manager MCDR plugin, based on MCSManager.",

--- a/mirror_mcsmcdr/__init__.py
+++ b/mirror_mcsmcdr/__init__.py
@@ -1,5 +1,4 @@
-from mcdreforged.api.all import PluginCommandSource
 from mirror_mcsmcdr.mirror_manager import MultiMirrorManager
 
-def on_load(server: PluginCommandSource, prev_module):
+def on_load(server, prev_module):
     manager = MultiMirrorManager(server)

--- a/mirror_mcsmcdr/mirror_manager.py
+++ b/mirror_mcsmcdr/mirror_manager.py
@@ -195,6 +195,9 @@ class MirrorManager: # The single mirror server manager which manages a specific
     @catch_api_error
     def _execute(self, source: CommandSource, command: str, available_status: list): # <failed_prompt> & <succeeded_prompt> : {status_code: "prompt"}
         status_code = self.server_api.status()
+        if not self.status_available(status_code):
+            source.reply(self.rtr(f"command.status.fail.{status_code}"))
+            return False
         if status_code in available_status:
             rep = getattr(self.server_api, command)()
             if rep == "success":

--- a/mirror_mcsmcdr/mirror_manager.py
+++ b/mirror_mcsmcdr/mirror_manager.py
@@ -1,10 +1,10 @@
-from mcdreforged.api.all import PluginServerInterface, CommandSource, CommandContext, Info, SimpleCommandBuilder, new_thread, RTextList, RAction
+from mcdreforged.api.all import PluginServerInterface, CommandSource, CommandContext, Info, SimpleCommandBuilder, new_thread, RTextList, RText, RAction, RColor
 from mirror_mcsmcdr.constants import DEFAULT_CONFIG, TITLE
 from mirror_mcsmcdr.utils.proxy.mcsm_proxy import MCSManagerProxyError
-from mirror_mcsmcdr.utils.server_utils import ServerProxy
+from mirror_mcsmcdr.utils.server_utils import ServerProxy, ProxySettingException, TerminalSettingException
 from mirror_mcsmcdr.utils.file_operation import WorldSync
 from mirror_mcsmcdr.utils.display_utils import rtr, help_msg
-from typing import Callable, Optional
+from typing import Callable, Optional, TypedDict, Dict
 from threading import Event, Timer
 from copy import deepcopy
 import time, re
@@ -77,36 +77,38 @@ class MultiMirrorManager: # The manager at large which manage multi single mirro
         manager: MirrorManager = self.managers[prefix]
         config, default_conf = self.load_config_all()
         if prefix not in config.keys():
-            manager.config_error()
+            rtr("multi_manager.init.prefix_notfound", prefix = prefix)
+            manager.manager_available = False
             return False
         single_config = self._conf_update(default_conf, config[prefix])
         manager.reload_config(single_config)
+
+
+class ConfirmationInfoDict(TypedDict):
+    action: str
+    timer: Timer
 
 
 class MirrorManager: # The single mirror server manager which manages a specific mirror server
 
 
     def __init__(self, server: PluginServerInterface, config: dict, command_prefix: str, reload_method: Callable) -> None:
+        self.manager_available: bool = False
         self.server = server
 
         server.logger.info(rtr("manager.load", prefix = command_prefix))
         self.command_prefix = command_prefix
 
         # init flag
-        self.sync_flag = False
-        self.save_world_wait = Event()
+        self.sync_flag: bool = False
+        self.save_world_wait: Event = Event()
         self.save_world_wait.set()
-        self.confirmation = {}
+        self.confirmation: Dict[str, ConfirmationInfoDict] = {}
 
         # register mcdr command
         builder = SimpleCommandBuilder()
         builder.command(f"{command_prefix}", self.help)
         builder.command(f"{command_prefix} reload", lambda source, context: reload_method(command_prefix))
-        
-        # check config
-        if not self.set_config(config):
-            builder.register(server)
-            return
         builder.command(f"{command_prefix} help", self.help)
         builder.command(f"{command_prefix} status", self.status)
         builder.command(f"{command_prefix} start", self.start)
@@ -115,6 +117,9 @@ class MirrorManager: # The single mirror server manager which manages a specific
         builder.command(f"{command_prefix} sync", self.sync)
         builder.command(f"{command_prefix} confirm", self.confirm)
         builder.register(server)
+        if not self.set_config(config):
+            return
+        self.manager_available = True
 
 
     def rtr(self, key, title=True, *args, **kwargs):
@@ -126,36 +131,44 @@ class MirrorManager: # The single mirror server manager which manages a specific
             self.config, self.world_sync, self.permission, self.command_action, self.server_name = \
                 config, WorldSync(**config["sync"]), config["command"]["permission"], config["command"]["action"], config["display"]["server_name"]
             self.server_api = ServerProxy()
-            self.server_api.set_mcsm(**self.config["mcsm"])
-            self.server_api.set_rcon(**self.config["rcon"])
-            terminal = self.server_api.set_system(**self.config["terminal"])
-            if type(terminal) == str:
-                self.server.broadcast(self.rtr("manager.reload.fail.unavailable_system"))
+            for proxy in self.server_api.proxies:
+                try:
+                    getattr(self.server_api, "set_%s"%proxy)(**self.config[proxy])
+                except ProxySettingException as e:
+                    self.server.broadcast(self.rtr("manager.reload.fail.proxy", proxy = e.proxy, keys = "', '".join(e.missing_keys)))
+                except TerminalSettingException as e:
+                    self.server.broadcast(self.rtr("manager.reload.fail.unavailable_system"))
             return True
         except Exception as e:
-            self.config_error()
-            return False
+            if self.server.is_server_startup():
+                self.server.say(self.rtr("manager.reload.fail"))
+            self.server.logger.error(e, exc_info=e)
 
 
     def reload_config(self, config):
+        self.manager_available = False
         if not self.set_config(config):
-            self.config_error()
             return
-        self.broadcast(self.rtr("manager.reload.success"))
-
-
-    def config_error(self):
-        info = self.rtr("manager.reload.fail")
-        self.server.logger.warn(info)
-        self.server.say(info)
-
-
-    def broadcast(self, text):
-        self.server.broadcast(text)
+        self.server.broadcast(self.rtr("manager.reload.success"))
+        self.manager_available = True
 
 
     def help(self, source: CommandSource, context: CommandContext):
         source.reply(help_msg(self.server_name, self.command_prefix))
+        source.reply(self.proxy_info())
+
+
+    def proxy_info(self):
+        info = RTextList(rtr("command.proxy.title", False))
+        for proxy in self.server_api.proxies:
+            if (_proxy := getattr(self.server_api, proxy)):
+                text = RText(proxy, RColor.green).h(rtr("command.proxy.enabled", False))
+            elif _proxy is None:
+                text = RText(proxy, RColor.gray).h(rtr("command.proxy.disabled", False))
+            else:
+                text = RText(proxy, RColor.red).h(rtr("command.proxy.error", False))
+            info.append(" | ", text)
+        return info
 
 
     def check_permission(self, source: CommandSource, command: str):
@@ -173,7 +186,7 @@ class MirrorManager: # The single mirror server manager which manages a specific
         if status_code in available_status:
             rep = getattr(self.server_api, command)()
             if rep == "success":
-                self.broadcast(self.rtr("command._execute.success", prompt=self.rtr(f"command.{command}.success.{status_code}", title=False).to_legacy_text()))
+                self.server.broadcast(self.rtr("command._execute.success", prompt=self.rtr(f"command.{command}.success.{status_code}", title=False).to_legacy_text()))
                 return True
             status_code = rep
         source.reply(self.rtr("command._execute.fail", prompt=self.rtr(f"command.{command}.fail.{status_code}", title=False).to_legacy_text()))
@@ -184,6 +197,10 @@ class MirrorManager: # The single mirror server manager which manages a specific
         return status in ["unknown", "stopped", "stopping", "starting", "running"]
 
     def pre_check(self, command: str, source: CommandSource, context: CommandContext, confirm=False):
+        if not self.manager_available:
+            source.reply(self.rtr("manager.unavailable"))
+            return
+        
         operator = source.player if source.is_player else "[console]"
             
         # automatically cancel old operation
@@ -195,7 +212,7 @@ class MirrorManager: # The single mirror server manager which manages a specific
             return False
         if not confirm and self.command_action[command]["require_confirm"]:
             timer = Timer(self.command_action["confirm"]["timeout"], self.confirm_timer, args=[source, context, operator])
-            self.confirmation[operator] = {"func": getattr(self, command), "timer": timer, "action": command}
+            self.confirmation[operator] = {"action": command, "timer": timer}
             timer.start()
 
             run_command = f"{self.command_prefix} confirm"
@@ -210,7 +227,7 @@ class MirrorManager: # The single mirror server manager which manages a specific
         if not self.pre_check("status", source, context, confirm): return
         status_code = self.server_api.status()
         flag = "success" if self.status_available(status_code) else "fail"
-        self.broadcast(self.rtr(f"command._execute.{flag}", prompt=self.rtr(f"command.status.{flag}.{status_code}", title=False).to_legacy_text()))
+        self.server.broadcast(self.rtr(f"command._execute.{flag}", prompt=self.rtr(f"command.status.{flag}.{status_code}", title=False).to_legacy_text()))
 
 
     def start(self, source: CommandSource, context: CommandContext, confirm=False):
@@ -230,8 +247,7 @@ class MirrorManager: # The single mirror server manager which manages a specific
     @new_thread(f"{TITLE}-sync")
     @catch_api_error
     def sync(self, source: CommandSource, context: CommandContext, confirm=False):
-        if self.pre_check("sync", source, context, confirm) == False:
-            return
+        if not self.pre_check("sync", source, context, confirm): return
 
         if self.sync_flag:
             source.reply(self.rtr("command.sync.fail.task_exist"))
@@ -248,7 +264,7 @@ class MirrorManager: # The single mirror server manager which manages a specific
                 source.reply(self.rtr(f"command.sync.fail.{status_code}"))
                 return
             else: # restart server
-                self.broadcast(self.rtr("command.sync.auto_restart.restarting"))
+                self.server.broadcast(self.rtr("command.sync.auto_restart.restarting"))
                 if not self.stop(source, context, confirm=True):
                     return
                 interval, times = sync_action_config["check_status_interval"], sync_action_config["max_attempt_times"]
@@ -258,16 +274,16 @@ class MirrorManager: # The single mirror server manager which manages a specific
                     if status_code == "stopped":
                         break
                     if not self.status_available(status_code): # if status command is not available, skip and end
-                        self.broadcast(self.rtr("command.sync.auto_restart.fail", status=self.rtr(f"command.status.failed.{status_code}", title=False)))
+                        self.server.broadcast(self.rtr("command.sync.auto_restart.fail", status=self.rtr(f"command.status.failed.{status_code}", title=False)))
                         return
                 else:
-                    self.broadcast(self.rtr("command.sync.auto_restart.fail", status=self.rtr(f"command.status.success.{status_code}", title=False)))
+                    self.server.broadcast(self.rtr("command.sync.auto_restart.fail", status=self.rtr(f"command.status.success.{status_code}", title=False)))
                     return
                 auto_restart_flag = True
 
         self.sync_flag = True
         try:
-            self.broadcast(self.rtr("command.sync.success"))
+            self.server.broadcast(self.rtr("command.sync.success"))
             t = time.time()
 
             # save the world
@@ -289,10 +305,10 @@ class MirrorManager: # The single mirror server manager which manages a specific
             h, m = divmod(m, 60)
             t = ("%02d:"%h if h else "") + ("%02d:"%m if m else "") + ("%02d"%s if m or h else ("%.02f"%s).zfill(5))
             if paths_notfound:
-                self.broadcast(self.rtr("command.sync.skip_dictionary", paths='§f`§7'.join(paths_notfound)))
-            self.broadcast(self.rtr("command.sync.completed", time=t, changed_files_count=changed_files_count) if changed_files_count != 0 else self.rtr("command.sync.identical"))
+                self.server.broadcast(self.rtr("command.sync.skip_dictionary", paths='§f`§7'.join(paths_notfound)))
+            self.server.broadcast(self.rtr("command.sync.completed", time=t, changed_files_count=changed_files_count) if changed_files_count != 0 else self.rtr("command.sync.identical"))
         except Exception as e:
-            self.broadcast(self.rtr("command.sync.error", e=e))
+            self.server.broadcast(self.rtr("command.sync.error", e=e))
         self.sync_flag = False
 
         if auto_restart_flag:
@@ -318,7 +334,7 @@ class MirrorManager: # The single mirror server manager which manages a specific
     def confirm_end(self, operator, source: Optional[CommandSource] = None, context: Optional[CommandContext] = None):
         self.confirmation[operator]["timer"].cancel()
         if source != None and context != None:
-            self.confirmation[operator]["func"](source, context, True)
+            getattr(self, self.confirmation[operator]["action"])(source, context, True)
         self.confirmation.pop(operator)
 
 

--- a/mirror_mcsmcdr/mirror_manager.py
+++ b/mirror_mcsmcdr/mirror_manager.py
@@ -1,6 +1,6 @@
 from mcdreforged.api.all import PluginServerInterface, CommandSource, CommandContext, Info, SimpleCommandBuilder, new_thread, RTextList, RAction
 from mirror_mcsmcdr.constants import DEFAULT_CONFIG, TITLE
-from mirror_mcsmcdr.utils.api.mcsm_api import MCSManagerApiError
+from mirror_mcsmcdr.utils.proxy.mcsm_proxy import MCSManagerProxyError
 from mirror_mcsmcdr.utils.server_utils import ServerProxy
 from mirror_mcsmcdr.utils.file_operation import WorldSync
 from mirror_mcsmcdr.utils.display_utils import rtr, help_msg
@@ -15,7 +15,7 @@ def catch_api_error(func):
     def wrapper(self, source: CommandSource, command: str, *args, **kwargs):
         try:
             return func(self, source, command, *args, **kwargs)
-        except MCSManagerApiError as e:
+        except MCSManagerProxyError as e:
             source.reply(rtr("mcsm.error.request", e=e))
         except Exception as e:
             source.reply(rtr("mcsm.error.unknown", e=e))

--- a/mirror_mcsmcdr/utils/api/mcsm_api.py
+++ b/mirror_mcsmcdr/utils/api/mcsm_api.py
@@ -45,7 +45,7 @@ class AbstractHTTPApi(ABC):
     def kill(self) -> str:
         return "success"
 
-class MCSManagerApiError(Exception):
+class MCSManagerApiError(HTTPApiError):
 
     def __init__(self, req: Response) -> None:
         error = json.loads(req.text)

--- a/mirror_mcsmcdr/utils/api/mcsm_api.py
+++ b/mirror_mcsmcdr/utils/api/mcsm_api.py
@@ -1,7 +1,49 @@
 import requests, json
 from requests import Response
 from mirror_mcsmcdr.utils.display_utils import rtr
+from abc import ABC, abstractmethod
 
+class HTTPApiError(Exception):
+
+    def __init__(self, req: Response) -> None:
+        super().__init__("HTTPApiError")
+
+class AbstractHTTPApi(ABC):
+
+    def __init__(self, enable: bool, url: str, *args, **kwargs) -> None:
+        self.enable = enable
+        self.url = url if url[-1] != "/" else url[:-1]
+        self.params = kwargs
+        self.status_to_text = {
+            -1: "unknown",
+            0: "stopped",
+            1: "stopping",
+            2: "starting",
+            3: "running"
+        }
+    
+    def _request(self, path: str, exception: HTTPApiError = HTTPApiError):
+        req : Response = requests.get(url=self.url+path, params=self.params)
+        if req.status_code == 200:
+            return json.loads(req.text)
+        else:
+            raise exception(req)
+    
+    @abstractmethod
+    def status(self) -> str:
+        ...
+    
+    @abstractmethod
+    def start(self) -> str:
+        return "success"
+    
+    @abstractmethod
+    def stop(self) -> str:
+        return "success"
+    
+    @abstractmethod
+    def kill(self) -> str:
+        return "success"
 
 class MCSManagerApiError(Exception):
 
@@ -14,30 +56,13 @@ class MCSManagerApiError(Exception):
         super().__init__(rtr(f"mcsm.error.{req.status_code}", title=False, error=error).to_plain_text())
 
 
-class MCSManagerApi:
+class MCSManagerApi(AbstractHTTPApi):
 
     def __init__(self, enable: bool, url: str, uuid: str, remote_uuid: str, apikey: str) -> None:
-        self.enable = enable
-        self.url = url if url[-1] != "/" else url[:-1]
-        self.params = {
-            "uuid": uuid,
-            "remote_uuid": remote_uuid,
-            "apikey": apikey
-        }
-        self.status_to_text = {
-            -1: "unknown",
-            0: "stopped",
-            1: "stopping",
-            2: "starting",
-            3: "running"
-        }
+        super().__init__(enable, url, uuid = uuid, remote_uuid = remote_uuid, apikey = apikey)
     
     def _request(self, path: str):
-        req : Response = requests.get(url=self.url+path, params=self.params)
-        if req.status_code == 200:
-            return json.loads(req.text)
-        else:
-            raise MCSManagerApiError(req)
+        return super()._request(path, MCSManagerApiError)
     
     def status(self):
         return self.status_to_text[self._request("/api/instance")["data"]["status"]]

--- a/mirror_mcsmcdr/utils/chunk_utils.py
+++ b/mirror_mcsmcdr/utils/chunk_utils.py
@@ -1,0 +1,16 @@
+DIMENSION = {
+    "overworld": "region",
+    "the_nether": "DIM1",
+    "the_end": "DIM-1"
+}
+
+class Region:
+    
+    def __init__(self, region_x: int, region_y: int, dimension_path: str):
+        self.filename = f"{dimension_path}/r.{region_x}.{region_y}"
+    
+    def get_region_by_pos(x: int, y: int, dimension: str):
+        return Region(x//16//32, y//16//32, DIMENSION[dimension])
+    
+    def load_region():
+        pass

--- a/mirror_mcsmcdr/utils/chunk_utils.py
+++ b/mirror_mcsmcdr/utils/chunk_utils.py
@@ -1,4 +1,5 @@
 import os
+from typing import List, Union
 
 DIMENSION = {
     "overworld": "region",
@@ -18,7 +19,7 @@ class Region:
         self.init_chunks()
     
     def init_chunks(self):
-        self.chunks = [None]*1024
+        self.chunks: List[Union[bytes, None]] = [None]*1024
     
     def get_chunk(self, chunk_x, chunk_z) -> bytes:
         chunk = self.chunks[index := chunk_z*32 + chunk_x]
@@ -90,7 +91,7 @@ class World:
         return region
 
     def get_region_by_pos(self, x: int, z: int, dimension: str) -> Region:
-        return self.get_region(self, x//16//32, z//16//32, dimension)
+        return self.get_region(x//16//32, z//16//32, dimension)
     
     def get_chunk_by_index(self, chunk_x: int, chunk_z: int, dimension: str) -> bytes:
         return self.get_region(chunk_x // 32, chunk_z // 32, dimension).get_chunk(chunk_x % 32, chunk_z % 32)

--- a/mirror_mcsmcdr/utils/chunk_utils.py
+++ b/mirror_mcsmcdr/utils/chunk_utils.py
@@ -1,16 +1,105 @@
+import os
+
 DIMENSION = {
     "overworld": "region",
     "the_nether": "DIM1",
     "the_end": "DIM-1"
 }
 
+class World:
+
+    def __init__(self, world_path: str) -> None:
+        self.loaded_region = {}
+        self.world_path = world_path
+    
+    def get_region_by_pos(self, x: int, y: int, dimension: str):
+        region_x, region_y = (x//16//32, y//16//32)
+        if (key := (region_x, region_y, dimension)) not in self.loaded_region.keys():
+            region = Region(x//16//32, y//16//32, DIMENSION[dimension], self.world_path)
+            self.loaded_region[key] = region
+        else:
+            region = self.loaded_region[key]
+        return region
+    
+    def get_chunk_by_pos(self, x: int, y: int, dimension: str):
+        return self.get_region_by_pos(x, y, dimension).get_chunk(x//16%32, y//16%32)
+    
+    def replace_chunk_by_pos(self, x: int, y: int, dimension: str, content: bytes):
+        self.get_region_by_pos(x, y, dimension).replace_chunk(x//16%32, y//16%32, content)
+    
+    def clear_all(self):
+        self.loaded_region.clear()
+    
+    def save_all(self):
+        for region in self.loaded_region.values():
+            region.save()
+        self.clear_all()
+
 class Region:
     
-    def __init__(self, region_x: int, region_y: int, dimension_path: str):
-        self.filename = f"{dimension_path}/r.{region_x}.{region_y}"
+    def __init__(self, region_x: int, region_y: int, dimension_path: str, world_path: str):
+        self.file = os.path.join(world_path, f"{dimension_path}/r.{region_x}.{region_y}.mca")
+        with open(self.file, "rb") as file:
+            pre4ksector = file.read(4096)
+        self.pre4ksector = [(pre4ksector[index:index+3], pre4ksector[index+3]) for index in range(0, 4096, 4)]
+        self.pre4ksector_changed = False
+        self.region_changed = False
+        self.init_chunks()
     
-    def get_region_by_pos(x: int, y: int, dimension: str):
-        return Region(x//16//32, y//16//32, DIMENSION[dimension])
+    def init_chunks(self):
+        self.chunks = [None]*1024
     
-    def load_region():
-        pass
+    def get_chunk(self, chunk_x, chunk_y):
+        chunk = self.chunks[index := chunk_y*32 + chunk_x]
+        if chunk:
+            return chunk
+        starter, size = self.pre4ksector[chunk_y*32 + chunk_x]
+        with open(self.file, "rb") as file:
+            file.seek(int.from_bytes(starter)*4096)
+            chunk = file.read(size*4096)
+        self.chunks[index] = chunk
+        return chunk
+    
+    def replace_chunk(self, chunk_x: int, chunk_y: int, content: bytes):
+        if not len(content)%4096 == 0:
+            raise AttributeError(f"Wrong chunk content format with length `{len(content)}`.")
+        new_size = len(content)//4096
+        starter, size = self.pre4ksector[index := chunk_y*32 + chunk_x]
+        self.chunks[index] = content
+        self.region_changed = True
+        if new_size == size:
+            return
+        size_change = new_size - size
+        self.pre4ksector = [i if i[0] <= starter else ((int.from_bytes(i[0]) + size_change).to_bytes(3), i[1]) for i in self.pre4ksector]
+        self.pre4ksector_changed = True
+    
+    def save(self):
+        if not self.region_changed:
+            return
+        with open(self.file, "rb") as file, open(self.file+".temp", "wb+") as temp:
+            if self.pre4ksector_changed:
+                file.seek(4096)
+                pre4ksector = bytes()
+                for i in self.pre4ksector:
+                    pre4ksector += i[0] + i[1].to_bytes()
+                temp.write(pre4ksector)
+            else:
+                temp.write(file.read(4096))
+            temp.write(file.read(4096))
+            chunks = {int.from_bytes(self.pre4ksector[index][0]):(self.pre4ksector[index][1], chunk) for index, chunk in enumerate(self.chunks) if chunk}
+            current_starter = 2
+            while True:
+                if current_starter not in chunks.keys():
+                    buffer = file.read(4096)
+                    if not buffer:
+                        break
+                    temp.write(buffer)
+                    current_starter += 1
+                    continue
+                size, chunk_content = chunks[current_starter]
+                file.seek(size*4096, 1)
+                temp.write(chunk_content)
+                current_starter += size
+                
+        os.remove(self.file)
+        os.rename(self.file+".temp", self.file)

--- a/mirror_mcsmcdr/utils/display_utils.py
+++ b/mirror_mcsmcdr/utils/display_utils.py
@@ -9,6 +9,6 @@ def rtr(key, title=True, *args, **kwargs):
 def help_msg(server_name, prefix):
     server = ServerInterface.si()
     msg = RTextList(server.rtr(PLUGIN_ID+".command.help.info", TITLE=TITLE, VERSION=VERSION))
-    for command in ["help", "status", "start", "stop", "kill", "sync", "reload"]:
+    for command in ["help", "reload", "status", "start", "stop", "kill", "sync"]:
         msg.append("\n",server.rtr(PLUGIN_ID+".command.help."+command, prefix=prefix, server_name=server_name).set_click_event(RAction.run_command, f"{prefix} {command}"))
     return msg

--- a/mirror_mcsmcdr/utils/proxy/mcsm_proxy.py
+++ b/mirror_mcsmcdr/utils/proxy/mcsm_proxy.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 class HTTPProxyError(Exception):
 
     def __init__(self, req: Response) -> None:
-        super().__init__("HTTPApiError")
+        super().__init__("HTTPProxyError")
 
 class AbstractHTTPProxy(ABC):
 
@@ -22,7 +22,7 @@ class AbstractHTTPProxy(ABC):
             3: "running"
         }
     
-    def _request(self, path: str, exception: HTTPProxyError = HTTPProxyError):
+    def _request(self, path: str, exception: type = HTTPProxyError):
         req : Response = requests.get(url=self.url+path, params=self.params)
         if req.status_code == 200:
             return json.loads(req.text)
@@ -45,7 +45,7 @@ class AbstractHTTPProxy(ABC):
     def kill(self) -> str:
         return "success"
 
-class MCSManagerProxyError(HTTPProxyError):
+class MCSManagerProxyError(Exception):
 
     def __init__(self, req: Response) -> None:
         error = json.loads(req.text)
@@ -61,8 +61,8 @@ class MCSManagerProxy(AbstractHTTPProxy):
     def __init__(self, enable: bool, url: str, uuid: str, remote_uuid: str, apikey: str) -> None:
         super().__init__(enable, url, uuid = uuid, remote_uuid = remote_uuid, apikey = apikey)
     
-    def _request(self, path: str):
-        return super()._request(path, MCSManagerProxyError)
+    def _request(self, path: str, exception: type = MCSManagerProxyError):
+        return super()._request(path, exception)
     
     def status(self):
         return self.status_to_text[self._request("/api/instance")["data"]["status"]]

--- a/mirror_mcsmcdr/utils/proxy/mcsm_proxy.py
+++ b/mirror_mcsmcdr/utils/proxy/mcsm_proxy.py
@@ -3,12 +3,12 @@ from requests import Response
 from mirror_mcsmcdr.utils.display_utils import rtr
 from abc import ABC, abstractmethod
 
-class HTTPApiError(Exception):
+class HTTPProxyError(Exception):
 
     def __init__(self, req: Response) -> None:
         super().__init__("HTTPApiError")
 
-class AbstractHTTPApi(ABC):
+class AbstractHTTPProxy(ABC):
 
     def __init__(self, enable: bool, url: str, *args, **kwargs) -> None:
         self.enable = enable
@@ -22,7 +22,7 @@ class AbstractHTTPApi(ABC):
             3: "running"
         }
     
-    def _request(self, path: str, exception: HTTPApiError = HTTPApiError):
+    def _request(self, path: str, exception: HTTPProxyError = HTTPProxyError):
         req : Response = requests.get(url=self.url+path, params=self.params)
         if req.status_code == 200:
             return json.loads(req.text)
@@ -45,7 +45,7 @@ class AbstractHTTPApi(ABC):
     def kill(self) -> str:
         return "success"
 
-class MCSManagerApiError(HTTPApiError):
+class MCSManagerProxyError(HTTPProxyError):
 
     def __init__(self, req: Response) -> None:
         error = json.loads(req.text)
@@ -56,13 +56,13 @@ class MCSManagerApiError(HTTPApiError):
         super().__init__(rtr(f"mcsm.error.{req.status_code}", title=False, error=error).to_plain_text())
 
 
-class MCSManagerApi(AbstractHTTPApi):
+class MCSManagerProxy(AbstractHTTPProxy):
 
     def __init__(self, enable: bool, url: str, uuid: str, remote_uuid: str, apikey: str) -> None:
         super().__init__(enable, url, uuid = uuid, remote_uuid = remote_uuid, apikey = apikey)
     
     def _request(self, path: str):
-        return super()._request(path, MCSManagerApiError)
+        return super()._request(path, MCSManagerProxyError)
     
     def status(self):
         return self.status_to_text[self._request("/api/instance")["data"]["status"]]

--- a/mirror_mcsmcdr/utils/proxy/rcon_proxy.py
+++ b/mirror_mcsmcdr/utils/proxy/rcon_proxy.py
@@ -1,6 +1,6 @@
 from mcdreforged.api.all import RconConnection
 
-class RConAPI:
+class RConProxy:
 
     def __init__(self, address: str, port: int, password: str) -> None:
         self.rcon = RconConnection(address, port, password)

--- a/mirror_mcsmcdr/utils/proxy/system_proxy.py
+++ b/mirror_mcsmcdr/utils/proxy/system_proxy.py
@@ -77,7 +77,7 @@ class WindowsProxy(AbstractSystemProxy):
         if not self.regex_strict or not text:
             return "running" if text else "stopped"
         for pid in set(re.findall(f":{port}.*?([0-9]+)\n", text)):
-            if re.match("java.exe", os.popen(f"tasklist | findstr {pid}")):
+            if re.match("java.exe", os.popen(f"tasklist | findstr {pid}").read()):
                 return "running"
         return "stopped"
     

--- a/mirror_mcsmcdr/utils/proxy/system_proxy.py
+++ b/mirror_mcsmcdr/utils/proxy/system_proxy.py
@@ -3,7 +3,25 @@ from abc import ABC, abstractmethod
 
 from mirror_mcsmcdr.constants import PLUGIN_ID
 
-class SystemProxy:
+class AbstractSystemProxy(ABC):
+
+    def __init__(self, terminal_name: str, path: str, command: str, port: int, regex_strict: bool) -> None:
+        self.terminal_name, self.path, self.command = terminal_name, path, command
+        self.port, self.regex_strict =  port, regex_strict
+    
+    @abstractmethod
+    def start(self) -> str:
+        ...
+    
+    @abstractmethod
+    def status(selfl) -> str:
+        ...
+    
+    @abstractmethod
+    def stop(self) -> str:
+        ...
+
+class SystemProxy(AbstractSystemProxy):
     
     def __init__(self, terminal_name: str, launch_path: str, launch_command: str, port: int, regex_strict: bool, system: str) -> None:
         self.system_api: AbstractSystemProxy
@@ -21,24 +39,6 @@ class SystemProxy:
     def stop(self):
         return self.system_api.stop()
 
-class AbstractSystemProxy(ABC):
-
-    def __init__(self, terminal_name: str, path: str, command: str, port: int, regex_strict: bool) -> None:
-        self.terminal_name, self.path, self.command = terminal_name, path, command
-        self.port, self.regex_strict =  port, regex_strict
-    
-    @abstractmethod
-    def start(self):
-        ...
-    
-    @abstractmethod
-    def status(selfl) -> str:
-        ...
-    
-    @abstractmethod
-    def stop(self):
-        ...
-
 class LinuxProxy(AbstractSystemProxy):
 
     def start(self):
@@ -49,7 +49,7 @@ class LinuxProxy(AbstractSystemProxy):
         os.popen(command)
         return "success"
     
-    def status(self) -> bool:
+    def status(self):
         port = self.port
         text = os.popen(f"lsof -i:{port}").read()
         if not self.regex_strict or not text:

--- a/mirror_mcsmcdr/utils/proxy/system_proxy.py
+++ b/mirror_mcsmcdr/utils/proxy/system_proxy.py
@@ -3,14 +3,14 @@ from abc import ABC, abstractmethod
 
 from mirror_mcsmcdr.constants import PLUGIN_ID
 
-class SystemAPI:
+class SystemProxy:
     
     def __init__(self, terminal_name: str, launch_path: str, launch_command: str, port: int, regex_strict: bool, system: str) -> None:
-        self.system_api: AbstractSystemAPI
+        self.system_api: AbstractSystemProxy
         if system == "Linux":
-            self.system_api = LinuxAPI(terminal_name+"_"+PLUGIN_ID, launch_path, launch_command, port, regex_strict)
+            self.system_api = LinuxProxy(terminal_name+"_"+PLUGIN_ID, launch_path, launch_command, port, regex_strict)
         elif system == "Windows":
-            self.system_api = WindowsAPI(terminal_name+"_"+PLUGIN_ID, launch_path, launch_command, port, regex_strict)
+            self.system_api = WindowsProxy(terminal_name+"_"+PLUGIN_ID, launch_path, launch_command, port, regex_strict)
 
     def start(self):
         return self.system_api.start()
@@ -21,7 +21,7 @@ class SystemAPI:
     def stop(self):
         return self.system_api.stop()
 
-class AbstractSystemAPI(ABC):
+class AbstractSystemProxy(ABC):
 
     def __init__(self, terminal_name: str, path: str, command: str, port: int, regex_strict: bool) -> None:
         self.terminal_name, self.path, self.command = terminal_name, path, command
@@ -39,7 +39,7 @@ class AbstractSystemAPI(ABC):
     def stop(self):
         ...
 
-class LinuxAPI(AbstractSystemAPI):
+class LinuxProxy(AbstractSystemProxy):
 
     def start(self):
         if not os.path.exists(self.path):
@@ -61,7 +61,7 @@ class LinuxAPI(AbstractSystemAPI):
         os.popen(command)
         return "success"
 
-class WindowsAPI(AbstractSystemAPI):
+class WindowsProxy(AbstractSystemProxy):
 
     def start(self):
         if not os.path.exists(self.path):

--- a/mirror_mcsmcdr/utils/server_utils.py
+++ b/mirror_mcsmcdr/utils/server_utils.py
@@ -1,24 +1,24 @@
-from mirror_mcsmcdr.utils.api.mcsm_api import MCSManagerApi
-from mirror_mcsmcdr.utils.api.rcon_api import RConAPI
-from mirror_mcsmcdr.utils.api.system_api import SystemAPI
+from mirror_mcsmcdr.utils.proxy.mcsm_proxy import MCSManagerProxy
+from mirror_mcsmcdr.utils.proxy.rcon_proxy import RConProxy
+from mirror_mcsmcdr.utils.proxy.system_proxy import SystemProxy
 import platform
 
 class ServerProxy:
 
     def __init__(self) -> None:
-        self.mcsm : MCSManagerApi = None
-        self.rcon : RConAPI = None
-        self.system : SystemAPI = None
+        self.mcsm : MCSManagerProxy = None
+        self.rcon : RConProxy = None
+        self.system : SystemProxy = None
     
     def set_mcsm(self, enable, url, uuid, remote_uuid, apikey):
         if enable and url and uuid and remote_uuid and apikey:
-            self.mcsm = MCSManagerApi(enable, url, uuid, remote_uuid, apikey)
+            self.mcsm = MCSManagerProxy(enable, url, uuid, remote_uuid, apikey)
             return True
 
     
     def set_rcon(self, enable, address, port, password):
         if enable and address and port and password:
-            self.rcon = RConAPI(address, port, password)
+            self.rcon = RConProxy(address, port, password)
             return True
         
     
@@ -28,7 +28,7 @@ class ServerProxy:
                 system = platform.system()
                 if system not in ["Linux", "Windows"]:
                     return system
-            self.system = SystemAPI(terminal_name, launch_path, launch_command, port, regex_strict, system)
+            self.system = SystemProxy(terminal_name, launch_path, launch_command, port, regex_strict, system)
             return True
     
     def status(self):


### PR DESCRIPTION
# News
- 区块操作工具完成，预计在v1.5.0加入区块同步功能
- 自动检查`mcsm` `rcon` `terminal`的配置项，并在加载时提示哪些键值存在问题
- 现在上述三个接口可以被分别独立加载了，即其中一个接口配置存在问题不会阻碍其余两个接口的加载与使用
- 使用`!!mirror`指令时自动显示接口配置与启用状态
- 优化部分回显

# Fixes
- 修复在除`!!mirror status`指令中获取status时，部分翻译键名调用错误的问题
- 修复Windows系统下启用`terminal`的严格检查`regex_strict`失效的问题